### PR TITLE
Prepare qpcr edits

### DIFF
--- a/diagnostic_rt_qpcr/libraries/dataassociationkeys/definition.json
+++ b/diagnostic_rt_qpcr/libraries/dataassociationkeys/definition.json
@@ -1,6 +1,6 @@
 {
-  "id": 39,
-  "name": "DiagnosticRTqPCRHelper",
+  "id": 60,
+  "name": "DataAssociationKeys",
   "parent_class": "Library",
   "category": "Diagnostic RT-qPCR",
   "user_id": 1

--- a/diagnostic_rt_qpcr/libraries/dataassociationkeys/source.rb
+++ b/diagnostic_rt_qpcr/libraries/dataassociationkeys/source.rb
@@ -1,0 +1,5 @@
+module DataAssociationKeys
+  GROUP_SIZE_KEY = 'group_size'
+  COMPOSITION_NAME_KEY = 'composition_name'
+  TEMPLATE_KEY = 'template'
+end

--- a/diagnostic_rt_qpcr/libraries/diagnosticrtqpcrdebug/definition.json
+++ b/diagnostic_rt_qpcr/libraries/diagnosticrtqpcrdebug/definition.json
@@ -1,6 +1,6 @@
 {
-  "id": 39,
-  "name": "DiagnosticRTqPCRHelper",
+  "id": 61,
+  "name": "DiagnosticRTqPCRDebug",
   "parent_class": "Library",
   "category": "Diagnostic RT-qPCR",
   "user_id": 1

--- a/diagnostic_rt_qpcr/libraries/diagnosticrtqpcrdebug/source.rb
+++ b/diagnostic_rt_qpcr/libraries/diagnosticrtqpcrdebug/source.rb
@@ -1,0 +1,160 @@
+# typed: false
+# frozen_string_literal: true
+needs 'Collection Management/CollectionTransfer'
+needs 'Diagnostic RT-qPCR/DiagnosticRTqPCRHelper'
+needs 'Diagnostic RT-qPCR/DataAssociationKeys'
+
+module DiagnosticRTqPCRDebug
+  include CollectionTransfer
+  include DiagnosticRTqPCRHelper
+  include DataAssociationKeys
+
+  VERBOSE = false
+
+  def debug_parameters
+    {
+      group_size: 3,
+      program_name: 'CDC_TaqPath_CG',
+      debug_primer: [5, 8, 9], # rp, n1, n2,
+      debug_template: 'template',
+      debug_items: [257,
+                    256,
+                    256,
+                    256,
+                    256,
+                    256,
+                    256,
+                    256,
+                    256,
+                    256,
+                    256,
+                    256,
+                    256,
+                    256,
+                    256,
+                    256,
+                    256,
+                    256,
+                    256,
+                    256,
+                    256,
+                    256,
+                    256]
+    }
+  end
+
+  def setup_test(operations)
+    operations.each do |op|
+      setup_test_plate(collection: op.input('PCR Plate').collection)
+      op.set_input('Template', generate_samples(debug_parameters[:debug_items]))
+    end
+  end
+
+  # Populate test plate with qPCR Reactions and one no template control (NTC)
+  #
+  def setup_test_plate(collection:)
+    verbose = false
+    key = TEMPLATE_KEY
+    collection.associate(:program_name, debug_parameters[:program_name])
+    collection.associate(:group_size, debug_parameters[:group_size])
+    qpcr_reaction = Sample.find_by_name('Test qPCR Reaction')
+    ntc_item = Item.find(258)
+    layout_generator = PlateLayoutGeneratorFactory.build(
+      group_size: debug_parameters[:group_size],
+      method: :cdc_sample_layout
+    )
+    i = 0
+    loop do
+      layout_group = layout_generator.next_group
+      break unless layout_group.present?
+      layout_group.each do |r, c|
+        collection.set(r, c, qpcr_reaction)
+        next if i.positive?
+        part = collection.part(r, c)
+        inspect part, "part at #{[r, c]}" if verbose
+        part.associate(key, ntc_item)
+        inspect part.associations, "#{key} at #{[r, c]}" if verbose
+      end
+      i += 1
+    end
+    show_result(collection: collection) if verbose
+    inspect collection.parts.to_s if verbose
+  end
+
+  def generate_samples(debug_item_ids)
+    debug_items = []
+    debug_item_ids.each do |id|
+      debug_items.push(Item.find(id))
+    end
+    debug_items
+  end
+
+  def show_result(collection:)
+    show do
+      table highlight_non_empty(collection)
+    end
+  end
+
+end
+
+
+
+#   def setup_test(operations)
+#     operations.each do |op|
+#       op.input('PCR Plate').set(collection: generate_debug_container)
+#       op.set_input('Template', generate_samples(debug_parameters[:debug_items]))
+#     end
+#   end
+
+#   # TODO: this is pretty gross and hard coded yuck
+#   def generate_debug_container
+#     obj_type = ObjectType.find_by_name('96-well qPCR Plate')
+#     collection = Collection.new_collection(obj_type)
+#     collection.associate(:program_name, debug_parameters[:program_name])
+#     collection.associate(:group_size, debug_parameters[:group_size])
+
+#     add_primer_probe(collection)
+#     add_neg_control(collection)
+
+#     raise "the associations are #{collection.part(0,0).associations}"
+#     collection
+#   end
+
+#   def add_primer_probe(collection)
+#     debug_parameters[:debug_primer].each_with_index do |sample, idx|
+#       sample = Sample.find(sample)
+#       12.times do |col|
+#         row1 = 0 + idx
+#         row2 = 4 + idx
+#         collection.set(row1, col, sample)
+#         collection.set(row2, col, sample)
+#       end
+#     end
+#   end
+
+#   def add_neg_control(collection)
+#     microtiter_plate = MicrotiterPlateFactory.build(
+#       collection: collection,
+#       group_size: debug_parameters[:group_size],
+#       method: :sample_layout
+#     )
+#     item = Item.find(debug_parameters[:neg_control_sample])
+#     neg_group = microtiter_plate.next_empty(key: TEMPLATE_KEY)
+
+#     association_map = []
+#     neg_group.each { |r, c| association_map.push({ to_loc: [r, c] }) }
+#     transfer_from_item_to_collection(from_item: item,
+#                                      to_collection: microtiter_plate.collection,
+#                                      association_map: association_map,
+#                                      transfer_vol: { qty: 5, units: 'ul'})
+#     neg_group.each { |nxt| associate(index: nxt, key: TEMPLATE_KEY, data: item.id) }
+#   end
+
+#   def generate_samples(debug_item_ids)
+#     debug_items = []
+#     debug_item_ids.each do |id|
+#       debug_items.push(Item.find(id))
+#     end
+#     debug_items
+#   end
+# end

--- a/diagnostic_rt_qpcr/libraries/diagnosticrtqpcrhelper/source.rb
+++ b/diagnostic_rt_qpcr/libraries/diagnosticrtqpcrhelper/source.rb
@@ -8,10 +8,8 @@ needs 'Standard Libs/Pipettors'
 needs 'Standard Libs/LabwareNames'
 needs 'Collection Management/CollectionActions'
 needs 'Collection Management/CollectionDisplay'
-# needs 'Collection Management/CollectionTransfer'
-# needs 'Collection Management/CollectionLocation'
-# needs 'Collection Management/CollectionData'
-needs 'Microtiter Plates/PlateLayoutGenerator'
+needs 'Collection Management/CollectionTransfer'
+needs 'Diagnostic RT-qPCR/DataAssociationKeys'
 
 # Module for elements that are common throughout Diagnostic RT qPCR
 #
@@ -28,12 +26,66 @@ module DiagnosticRTqPCRHelper
   # Collection Management
   include CollectionActions
   include CollectionDisplay
-  # include CollectionTransfer
-  # include CollectionLocation
-  # include CollectionData
+  include CollectionTransfer
+
+  #Diagnostic RT-qPCR
+  include DataAssociationKeys
 
   WATER = 'Molecular Grade Water'
   RNA_FREE_WORKSPACE = 'reagent set-up room'
   PLATE = 'PCR Plate'
   PRIMER_MIX = 'Primer/Probe Mix'
+  TEMPLATE = 'Template'
+
+  def rnase_warning
+    show do
+      title 'RNase degrades RNA'
+      note 'RNA is prone to degradation by RNase present in our eyes, skin, and breath.'
+      note 'Avoid opening tubes outside the Biosafety Cabinet (BSC).'
+      bullet 'Change gloves whenever you suspect potential RNAse contamination'
+    end
+  end
+
+  def safety_warning
+    show do
+      title 'Review Safety Warnings'
+      note '<b>Always</b> pay attention to orange warning blocks throughout the protocol.'
+      warning '<b>INFECTIOUS MATERIALS</b>'
+      note 'You will be working with infectious materials.'
+      note 'Do <b>ALL</b> work in a biosafety cabinet (BSC).'
+      note '<b>PPE is required</b>'
+      check 'Put on lab coat.'
+      check 'Put on 2 layers of gloves.'
+      bullet 'Make sure to use tight gloves. Tight gloves reduce the chance of the gloves getting caught on the tubes when closing their lids.'
+      bullet 'Change outer layer of gloves after handling infectious sample and before touching surfaces outside of the BSC (such as a refrigerator door handle).'
+    end
+  end
+
+  # TODO: Think about how to switch this to row-wise addition.
+  # Adds samples to to collections, provides instructions to tech
+  #
+  # @param operation_inputs [Array<items>]
+  # @param collection [Collection]
+  # @param layout_generator [LayoutGenerator]
+  # @param volume [{aty: int, unit: string}]
+  # @param column [int]
+  def add_samples(operation_inputs:, microtiter_plate:,
+                  volume:, column: nil)
+    operation_inputs.each do |fv|
+      item = fv.item
+      layout_group = microtiter_plate.associate_next_empty_group(
+        key: TEMPLATE_KEY,
+        data: { item: item.id, volume: volume },
+        column: column
+      )
+
+      association_map = []
+      layout_group.each { |r, c| association_map.push({ to_loc: [r, c] }) }
+      single_channel_item_to_collection(to_collection: microtiter_plate.collection,
+                                        source: item,
+                                        volume: volume,
+                                        association_map: association_map)
+    end
+  end
+
 end

--- a/diagnostic_rt_qpcr/operation_types/prepare_rt_qpcr_plate/definition.json
+++ b/diagnostic_rt_qpcr/operation_types/prepare_rt_qpcr_plate/definition.json
@@ -1,5 +1,5 @@
 {
-  "id": 15,
+  "id": 4,
   "name": "Prepare RT-qPCR Plate",
   "parent_class": "OperationType",
   "category": "Diagnostic RT-qPCR",
@@ -11,23 +11,29 @@
       "routing": "T"
     },
     {
-      "name": "options",
-      "part": null,
-      "array": null,
+      "name": "Options",
+      "part": false,
+      "array": false,
       "routing": null
     },
     {
-      "name": "Input PCR Plate",
-      "part": null,
-      "array": null,
+      "name": "PCR Plate",
+      "part": false,
+      "array": false,
       "routing": "P"
+    },
+    {
+      "name": "Assay Type",
+      "part": false,
+      "array": false,
+      "routing": null
     }
   ],
   "outputs": [
     {
-      "name": "Output PCR Plate",
-      "part": null,
-      "array": null,
+      "name": "PCR Plate",
+      "part": false,
+      "array": false,
       "routing": "P"
     }
   ],

--- a/diagnostic_rt_qpcr/operation_types/prepare_rt_qpcr_plate/protocol.rb
+++ b/diagnostic_rt_qpcr/operation_types/prepare_rt_qpcr_plate/protocol.rb
@@ -1,112 +1,186 @@
+# typed: false
 # frozen_string_literal: true
 
-needs 'Diagnostic RT-qPCR/PrepareRTqPCRValidation'
-needs 'Diagnostic RT-qPCR/PrepareqPCRPlateHelper'
+needs 'Diagnostic RT-qPCR/DiagnosticRTqPCRHelper'
+needs 'Diagnostic RT-qPCR/DiagnosticRTqPCRDebug'
+needs 'Diagnostic RT-qPCR/DataAssociationKeys'
+needs 'PCR Libs/PCRComposition'
+needs 'Microtiter Plates/MicrotiterPlate'
+needs 'Collection Management/CollectionTransfer'
 
 # Protocol for setting up a plate with extracted RNA samples
 #
 # @author Devin Strickland <strcklnd@uw.edu>
 # @author Cannon Mallory <malloc3@uw.edu>
 class Protocol
-  include PrepareqPCRPlateHelper
-  include PrepareRTqPCRValidation
+  include DiagnosticRTqPCRHelper
+  include DiagnosticRTqPCRDebug
+  include MicrotiterPlates
+  include CollectionTransfer
+  include DataAssociationKeys
 
+  METHOD = :cdc_sample_layout
+
+  # Default parameters that are applied equally to all operations.
+  #   Can be overridden by:
+  #   * Associating a JSON-formatted list of key, value pairs to the `Plan`.
+  #   * Adding a JSON-formatted list of key, value pairs to an `Operation`
+  #     input of type JSON and named `Options`.
+  #
   def default_job_params
     {
-      primer_set: 'RP_N2',
-      max_inputs: 24,
-      group_size: 3,
-      method: 'sample_layout'.to_sym, 
-      additional_inputs: [
-        # {
-        #   name: nil,
-        #   container: nil,
-        #   station: 'bench'
-        #   volume{
-        #       qty: nil,
-        #       units: MIROLITERS
-        # }
-      ],
-      negative_controls: {
-        name: 'NTC',
-        first_well: [0, 0],
-        station: 'negative_control station',
-        volume: {
-          qty: 5,
-          units: MICROLITERS
-        },
-        additional_inputs: [
-          # {
-          #   name: nil,
-          #   container: nil,
-          #   station: nil,
-          #   volume{
-          #        qty: nil,
-          #        units: MIROLITERS
-          #   }
-          # }
-        ]
-      },
-      positive_controls:{
-        name: 'nCoVPC',
-        first_well: [0, 11],
-        station: 'positive control station',
-        volume: {
-          qty: 5,
-          units: MICROLITERS
-        },
-        additional_inputs: [
-          # {
-          #   name: nil,
-          #   container: nil,
-          #   station: nil,
-          #   volume{
-          #        qty: nil,
-          #        units: MIROLITERS
-          #   }
-          # }
-        ]
-      },
-      standard_samples: {
-        station: 'sample handling station',
-        volume: {
-          qty: 5,
-          units: MICROLITERS
-        },
-        additional_inputs: [
-          # {
-          #   name: nil,
-          #   container: nil,
-          #   station: nil,
-          #   volume{
-          #        qty: nil,
-          #        units: MIROLITERS
-          #   }
-          # }
-        ]
-      }
+      max_inputs: 24
     }
   end
 
+  # Default parameters that are applied to individual operations.
+  #   Can be overridden by:
+  #   * Adding a JSON-formatted list of key, value pairs to an `Operation`
+  #     input of type JSON and named `Options`.
+  #
   def default_operation_params
-    {}
+    {
+      negative_template_control: nil,
+      negative_template_location: nil,
+      positive_template_control: 'Test nCoVPC',
+      positive_template_location: [0, 11]
+    }
   end
 
   def main
-    operations.reject!{ |op| validate(operations: operations).include?(op) }
-    return {} if operations.empty?
+    #========= Setup Job ==========#
+    setup_test(operations) if debug
+    @job_params = update_all_params(
+      operations: operations,
+      default_job_params: default_job_params,
+      default_operation_params: default_operation_params
+    )
 
-    operations.retrieve
+    #========= Validation =========#
+    validate(operations: operations)
+    return {} if operations.errored.any?
 
+    #====== General Warnings =====#
+    rnase_warning
+    safety_warning
+
+    operations.retrieve.make
+
+    #====== Core Operation ======#
     operations.each do |op|
-      run_job(default_job_params: default_job_params,
-              default_operation_params: default_operation_params,
-              op: op)
+      op.pass(PLATE)
+      output_collection = op.output(PLATE).collection
+      group_size = output_collection.get(:group_size)
+      program_name = output_collection.get(:program_name)
+
+      microtiter_plate = MicrotiterPlateFactory.build(
+        collection: output_collection,
+        group_size: group_size,
+        method: METHOD
+      )
+
+      composition = PCRCompositionFactory.build(
+        program_name: program_name
+      )
+      volume = { qty: composition.template.qty,
+                 units: composition.template.units }
+
+      remaining_inputs = add_control_samples(
+        operation_inputs: op.input_array(TEMPLATE),
+        microtiter_plate: microtiter_plate,
+        volume: volume,
+        operation_parameters: op.temporary[:options]
+      )
+
+      add_diagnostic_samples(
+        operation_inputs: remaining_inputs,
+        microtiter_plate: microtiter_plate,
+        volume: volume
+      )
+
+      seal_plate(output_collection)
+      show_result(collection: output_collection) if debug
     end
 
     operations.store
 
     {}
-
   end
+
+  # Provides instructions and handling for addition of control
+  # samples.  Returns all inputs that are NOT control inputs
+  #
+  # @param operation_inputs [Array<item>]
+  # @param collection [Collection]
+  # @param layout_generator [LayoutGenerator]
+  # @param volume [{aty: int, unit: string}]
+  # @return operation_inputs [Array<item>]
+  def add_control_samples(operation_inputs:, microtiter_plate:,
+                          volume:, operation_parameters:)
+    %w[negative_template positive_template].each do |stub|
+      name = operation_parameters["#{stub}_control".to_sym]
+      loc = operation_parameters["#{stub}_location".to_sym]
+
+      next unless name.present? && loc.present?
+
+      control_inputs, operation_inputs = operation_inputs.partition do |fv|
+        fv.sample.name == name
+      end
+
+      add_samples(
+        operation_inputs: control_inputs,
+        microtiter_plate: microtiter_plate,
+        volume: volume,
+        column: loc[1]
+      )
+
+      # negative control samples need to be covered after addition
+      next unless stub.include?('negative')
+
+      seal_plate(collection, rc_list: get_rna_samples(collection))
+    end
+    operation_inputs
+  end
+
+  # Provides instructions to add diagnostic samples to collection
+  #
+  # @param operation_inputs [Array<items>]
+  # @param collection [Collection]
+  # @param layout_generator [LayoutGenerator]
+  # @param volume [{aty: int, unit: string}]
+  def add_diagnostic_samples(operation_inputs:, microtiter_plate:,
+                            volume:)
+    add_samples(
+      operation_inputs: operation_inputs,
+      microtiter_plate: microtiter_plate,
+      volume: volume
+    )
+  end
+
+  # validates operations and ensures that they are formatted as expected
+  #
+  # @param operations [OperationList]
+  def validate(operations:)
+    operations.each do |op|
+      if op.input_array(TEMPLATE).length > @job_params[:max_inputs]
+        raise IncompatibleInputsError, "Too many inputs for Operation #{op.id}"
+      end
+    end
+  rescue IncompatibleInputsError => e
+    error_operations(operations: operations, err: e)
+  end
+
+  # Say you're quitting due to an error and error all the operations
+  #
+  def error_operations(operations:, err:)
+    show do
+      title 'Incompatible Inputs Detected'
+      warning err.message
+    end
+
+    operations.each { |op| op.error(:incompatible_inputs, err.message) }
+  end
+
+  class IncompatibleInputsError < ProtocolError; end
+  class NoAvailableWells < ProtocolError; end
 end

--- a/diagnostic_rt_qpcr/operation_types/prepare_rt_qpcr_plate/test.rb
+++ b/diagnostic_rt_qpcr/operation_types/prepare_rt_qpcr_plate/test.rb
@@ -1,0 +1,10 @@
+class ProtocolTest < ProtocolTestBase
+    def setup
+      add_random_operations(1)
+    end
+  
+    def analyze
+      log('Hello from Nemo')
+      assert_equal(@backtrace.last[:operation], 'complete')
+    end
+  end


### PR DESCRIPTION
Changes made here.   Libraries "PrepareRT-qPCRValidation" and "PrepareRT-qPCRHelper" can be deleted from main branch.   This protocol only uses the libraries listed in this pull request.